### PR TITLE
0.5.x

### DIFF
--- a/app/Config/config-dev.json
+++ b/app/Config/config-dev.json
@@ -1,0 +1,70 @@
+{
+    "application": {
+        "code": "${application-code}",
+        "name": "${application-name}",
+        "version": "${application-version}",
+        "global": {
+            "maintenance": false,
+            "message": "We are in maintenance mode, back shortly",
+            "timezone": "Europe\/Stockholm"
+        },
+        "secret": "${application-secret}"
+    },
+    "log": {
+        "level": "error",
+        "driver": "php",
+        "drivers": {
+            "php": {
+                "line_format": "[%channel%] [%level_name%] %message% %context%",
+                "line_datetime": "Y-m-d H:i:s.v e"
+            },
+            "file": {
+                "file_path": "storage\/log",
+                "file_format": "Y-m-d",
+                "line_format": "[%datetime%] [%channel%] [%level_name%] %message% %context%",
+                "line_datetime": "Y-m-d H:i:s.v e"
+            }
+        }
+    },
+    "cache": {
+        "driver": "Apcu",
+        "options": {}
+    },
+    "connections": {
+        "default_firebird": {
+            "type": "Pdo",
+            "driver": "firebird",
+            "schema": "<path_to_db>",
+            "host": "localhost",
+            "port": 3050,
+            "username": "sysdba",
+            "password": "********",
+            "charset": "UTF8",
+            "options": [
+                {"ATTR_PERSISTENT": true},
+                {"ATTR_ERRMODE": "ERRMODE_EXCEPTION"},
+                {"ATTR_AUTOCOMMIT": false}
+            ]
+        },
+        "default_mysql": {
+            "type": "Pdo",
+            "driver": "mysql",
+            "schema": "<db_schema_name>",
+            "host": "localhost",
+            "port": 3306,
+            "username": "root",
+            "password": "*****",
+            "charset": "UTF8",
+            "options": [
+                {"ATTR_PERSISTENT": true},
+                {"ATTR_ERRMODE": "ERRMODE_EXCEPTION"},
+                {"ATTR_AUTOCOMMIT": false}
+            ]
+        },
+        "example_sqlite": {
+            "type": "Pdo",
+            "driver": "SqlLite",
+            "filename": "storage\\database\\db.sqlite"
+        }
+    }
+}

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,11 +2,11 @@
 See [Roadmap](roadmap.md) for details on whats in the pipe
 
 # v0.5.7
-Breaking changes in 0.5.7:
-* New: Config file loaded based on "ENVIRONMENT" variable. This env-var can be set in Apache VHOST/.htaccess. Defaults to `dev` environment
-* New: Config param `application.environment` deprecated, and is now read from the environment variable `ENVIRONMENT`
+*Breaking changes:*
+* New: Config file loaded based on env var `ENVIRONMENT`. This env var can be set in Apache VHOST/.htaccess. Defaults to `dev`
+* New: Config param `application.environment` deprecated, and is now read from the env var `ENVIRONMENT`
 
-Non-breaking changes:
+*Non-breaking changes:*
 * Added a sample `app/Config/config-dev.json` file to the framework
 
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,15 @@
 # Changelog
 See [Roadmap](roadmap.md) for details on whats in the pipe
 
+# v0.5.7
+Breaking changes in 0.5.7:
+* New: Config file loaded based on "ENVIRONMENT" variable. This env-var can be set in Apache VHOST/.htaccess. Defaults to `dev` environment
+* New: Config param `application.environment` deprecated, and is now read from the environment variable `ENVIRONMENT`
+
+Non-breaking changes:
+* Added a sample `app/Config/config-dev.json` file to the framework
+
+
 # v0.5.6
 * Added param to define JSON encoding options on `setJsonBody()` and `errorJson()` methods. Defaults to `JSON_PRETTY_PRINT` to maintain compatibility
 * Bugfix for retry-sleep in Nofuzz\Http\Client
@@ -23,7 +32,7 @@ See [Roadmap](roadmap.md) for details on whats in the pipe
 * Added Units-Tests for many things (work in progress)
 * PHP 7.1.3 compatibility verified
 * errorHandler() in application.php fixed to not log unwanted data
-* Renamed "BaseDao" to "AbstractBaseDao" and "BaseDBObject" to "AbstractBaseEntity" 
+* Renamed "BaseDao" to "AbstractBaseDao" and "BaseDBObject" to "AbstractBaseEntity"
 * AbstractBaseDao rawQuery() and rawExec() methods added
 
 # v0.5.2

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,7 +8,8 @@ See [Roadmap](roadmap.md) for details on whats in the pipe
 
 *Non-breaking changes:*
 * Added a sample `app/Config/config-dev.json` file to the framework
-
+* Added JSON_NUMERIC_CHECK to default options for `HTTPResponse->errorJson()` and `HTTPResponse->setJsonBody()`
+* CHanged `HTTPResponse->errorJson()` to use `HTTPResponse->setJsonBody()` when finally setting the body
 
 # v0.5.6
 * Added param to define JSON encoding options on `setJsonBody()` and `errorJson()` methods. Defaults to `JSON_PRETTY_PRINT` to maintain compatibility

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -48,7 +48,7 @@ error_log = "<path>/php/logs/error.log"
 extension=php_mbstring.dll
 extension=php_openssl.dll
 
-; Enable all needed PDO drivers 
+; Enable all needed PDO drivers
 ;extension=php_pdo_firebird.dll
 ;extension=php_pdo_mysql.dll
 
@@ -80,37 +80,43 @@ Include conf/extra/httpd-vhosts.conf
 ```
 
 ### conf/extra/httpd-vhosts.conf
-_Tip: In the VHOST definition you can SET ENVIRONMENT options with `SetEnv <variable> <value>`, and later access these in PHP via `$_ENV[<variable>]` or the helper `env('<variable>')`_
+_Tip: In the VHOST definition you can set environment options with `SetEnv <variable> <value>`, and later access these in PHP via `$_ENV[<variable>]` or the global function `env('<variable>')`_
 
 ```txt
 # Define constants for the application
-Define NF_APP_NAME      "myapp"
 Define NF_APP_DOMAIN    "api.mydomain.com"
+Define NF_APP_CODE      "myapp"
 Define NF_APP_PATH      "/var/www/applications/my_app"
 Define NF_APP_EMAIL     "admin@mydomain.com"
-Define NF_APP_ENV       "DEV"
+Define NF_APP_ENV       "dev"
 
 # VHost definition
 <VirtualHost *:80>
-  ServerName {$NF_APP_DOMAIN}
-  ServerAdmin {$NF_APP_EMAIL}
+  ServerName ${NF_APP_DOMAIN}
+  ServerAdmin ${NF_APP_EMAIL}
   DocumentRoot "${NF_APP_PATH}/src/public"
 
-  ErrorLog "logs/${NF_APP_NAME}-error.log"
-  CustomLog "logs/${NF_APP_NAME}-access.log" common
+  ErrorLog "logs/${NF_APP_CODE}-error.log"
+  CustomLog "logs/${NF_APP_CODE}-access.log" common
 
   <Directory "${NF_APP_PATH}/src/public">
     <IfModule mod_negotiation.c>
         Options -MultiViews
     </IfModule>
+
     SetEnv ENVIRONMENT ${NF_APP_ENV}
-    DirectoryIndex bootstrap.php
+
+    # Try to load files in order of appearance if requeest matches a dir
+    DirectoryIndex bootstrap.php index.html index.htm index.php
+
     Options -Indexes +FollowSymLinks
     AllowOverride All
     Order allow,deny
     Allow from all
     Require all granted
+
     DirectorySlash Off
+
     # Rewrite Engine to direct all requests to bootstrap.php file
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-d
@@ -121,7 +127,8 @@ Define NF_APP_ENV       "DEV"
 ```
 
 ### Using .htaccess file
-You can alos use the `.htaccess` file to rewrite requests to the bootstrap file, but this is not recommeded. The biggest reason being performance.
+You can also use the `.htaccess` file to rewrite requests to the bootstrap file, but this is not recommeded.
+The biggest reason being performance.
 
 ```txt
     SetEnv ENVIRONMENT PROD
@@ -134,7 +141,7 @@ You can alos use the `.htaccess` file to rewrite requests to the bootstrap file,
 ```
 
 ## Config options
-The default Config files is located at `/app/config/config.json`
+The default Config files is located at `/app/config/config-${environment}.json`
 Below is an example configuration from the [Nofuzz-Tutorial-Blog](https://github.com/Celarius/nofuzz-tutorial-blog-api) application.
 Values you should change for every application are:
 - Application
@@ -151,7 +158,6 @@ Values you should change for every application are:
         "global": {
             "maintenance": false,
             "message": "We are in maintenance mode, back shortly",
-            "environment": "DEV",
             "timezone": "Europe\/Stockholm"
         },
         "secret": "This Value Needs To Be Changed To Something Random"
@@ -185,7 +191,7 @@ In order to deploy to production do the following:
 2. Configure Apache httpd.conf & vhost.conf
 3. Copy/Clone php application files to target dir
 4. Set environment specific config options in `/app/Config/config.json`
-5. Update Composer & Packages (see below) 
+5. Update Composer & Packages (see below)
 6. Restart Apache
 
 ## Directory Structure
@@ -203,7 +209,7 @@ A basic Nofuzz application has the following structure. The `/app` folder will c
 
 
 ## Composer update
-Run the following composer command to update & generate optimized autoload files: 
+Run the following composer command to update & generate optimized autoload files:
 ```txt
 composer self-update
 composer update --no-dev -o

--- a/src/Application.php
+++ b/src/Application.php
@@ -67,7 +67,7 @@ class Application
     $this->code = $this->getConfig()->get('application.code','');
     $this->name = $this->getConfig()->get('application.name','');
     $this->version = $this->getConfig()->get('application.version');
-    $this->environment = ( env('ENVIRONMENT') ?? $this->getConfig()->get('application.global.environment') ?? 'DEV' );
+    $this->environment = ( env('ENVIRONMENT') ?? $this->getConfig()->get('application.global.environment') ?? 'dev' );
 
     # Create Logger
     $this->createLogger( $this->code );

--- a/src/Application.php
+++ b/src/Application.php
@@ -53,7 +53,11 @@ class Application
     $this->routeGroups = array();
 
     # Create Config
-    $this->config = new \Nofuzz\Config\Config($this->basePath.'/app/Config/config.json');
+    # v0.5.7: (KS) Made loading the config based on environment variable
+    $env = strtolower(env('ENVIRONMENT','dev'));
+    $config_file = str_replace('-${environment}', $env, $this->basePath.'/app/Config/config-${environment}.json');
+    # Create the config
+    $this->config = new \Nofuzz\Config\Config($config_file);
 
     # Set Timezone - default to UTC
     $timeZone = $this->getConfig()->get('application.global.timezone','UTC');
@@ -63,7 +67,7 @@ class Application
     $this->code = $this->getConfig()->get('application.code','');
     $this->name = $this->getConfig()->get('application.name','');
     $this->version = $this->getConfig()->get('application.version');
-    $this->environment = ( $this->getConfig()->get('application.global.environment') ?? env('Environment') ?? 'DEV' );
+    $this->environment = ( env('ENVIRONMENT') ?? $this->getConfig()->get('application.global.environment') ?? 'DEV' );
 
     # Create Logger
     $this->createLogger( $this->code );

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -46,7 +46,7 @@ class Config implements \Nofuzz\Config\ConfigInterface
    */
   public function load(string $filename): \Nofuzz\Config\Config
   {
-    # Attempt to load config file and merge it - Current Directory (config.json)
+    # Attempt to load config file
     if ( file_exists($filename) ) {
       # Set filename
       $this->filename = $filename;
@@ -73,7 +73,7 @@ class Config implements \Nofuzz\Config\ConfigInterface
    */
   public function loadAndMerge(string $filename): \Nofuzz\Config\Config
   {
-    # Attempt to load config file and merge it - Current Directory (config.json)
+    # Attempt to load config file
     if ( file_exists($filename) ) {
       # Set filename
       $this->filename = $filename;

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -49,7 +49,7 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
 
   /**
    * clear - Clear all properties
-   * 
+   *
    * @return self
    */
   public function clear()
@@ -71,7 +71,7 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
    *
    * @param boolean $active   True for activating compression
    * @param int $level        Compression level. -1=Auto, 0=None, 9=Max
-   * 
+   *
    * @return self
    */
   public function setCompression(bool $active = true, int $level = -1)
@@ -97,7 +97,7 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
 
   /**
    * Send response to client
-   * 
+   *
    * @return self
    */
   public function send()
@@ -222,7 +222,7 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
 
       default: $this->statusText = '(Unused)'; break;
     }
-    
+
     # Return the text
     return $this->statusText;
   }
@@ -279,10 +279,10 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
    * @param   int    $code          HTTP Code to set
    * @param   string $message       Message to send
    * @param   string $details       Details. Optional.
-   * @param   int|integer $options  Optional json_encode() options. Defaults to JSON_PRETTY_PRINT to maintain backwards compatibilitiy
+   * @param   int|integer $options  Optional json_encode() options. Default = JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK
    * @return  self
    */
-  public function errorJson(int $code, string $message, string $details='', int $options=JSON_PRETTY_PRINT): \Nofuzz\Http\HTTPResponse
+  public function errorJson(int $code, string $message, string $details='', int $options=JSON_PRETTY_PRINT|JSON_NUMERIC_CHECK): \Nofuzz\Http\HTTPResponse
   {
     $message = $this->setTextFromCode($code, $message);
 
@@ -291,10 +291,7 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
     $data['message'] = $message;
     if (strlen($details)>0) $data['details'] = $details;
 
-    # Set Headers
-    $this->setContentType('application/json');
-
-    return $this->error($code,json_encode($data,$options));
+    return $this->setJsonBody($data,$options);
   }
 
   #
@@ -467,10 +464,10 @@ class HttpResponse implements \Nofuzz\Http\HttpResponseInterface
    * setJsonBody - Encodes array as JSON response
    *
    * @param   array       $data     Array to send as JSON
-   * @param   int|integer $options  Optional json_encode() options. Defaults to JSON_PRETTY_PRINT to maintain backwards compatibilitiy
+   * @param   int|integer $options  Optional json_encode() options. Default = JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK
    * @return  self
    */
-  public function setJsonBody(array $data, int $options=JSON_PRETTY_PRINT)
+  public function setJsonBody(array $data, int $options=JSON_PRETTY_PRINT|JSON_NUMERIC_CHECK)
   {
     $this->setContentType('application/json')
          ->setBody( json_encode($data,$options) );

--- a/src/Http/HttpResponseInterface.php
+++ b/src/Http/HttpResponseInterface.php
@@ -31,7 +31,7 @@ interface HttpResponseInterface
   function setHeaders(array $headers);
   function setHeader(string $header, string $value);
   function setBody(string $body='');
-  function setJsonBody(array $data, int $options=JSON_PRETTY_PRINT);
+  function setJsonBody(array $data, int $options=JSON_PRETTY_PRINT|JSON_NUMERIC_CHECK);
   function setFileBody(string $fileBody, string $contentType='');
   function setCacheControl(string $value);
   function setContentType(string $value);
@@ -42,5 +42,5 @@ interface HttpResponseInterface
   function success(int $code, string $body=''): \Nofuzz\Http\HTTPResponse;
   function redirect(int $code, string $url): \Nofuzz\Http\HTTPResponse;
   function error(int $code, string $body=''): \Nofuzz\Http\HTTPResponse;
-  function errorJson(int $code, string $message, string $details='', int $options=JSON_PRETTY_PRINT): \Nofuzz\Http\HTTPResponse;
+  function errorJson(int $code, string $message, string $details='', int $options=JSON_PRETTY_PRINT|JSON_NUMERIC_CHECK): \Nofuzz\Http\HTTPResponse;
 }


### PR DESCRIPTION
*Breaking changes:*
* New: Config file loaded based on env var `ENVIRONMENT`. This env var can be set in Apache VHOST/.htaccess. Defaults to `dev`
* New: Config param `application.environment` deprecated, and is now read from the env var `ENVIRONMENT`

*Non-breaking changes:*
* Added a sample `app/Config/config-dev.json` file to the framework
* Added JSON_NUMERIC_CHECK to default options for `HTTPResponse->errorJson()` and `HTTPResponse->setJsonBody()`
* Changed `HTTPResponse->errorJson()` to use `HTTPResponse->setJsonBody()` when finally setting the body
